### PR TITLE
Removed main merge trigger from choco push and updated nuget refs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -136,7 +136,7 @@ jobs:
           done
 
       - name: Push the Chocolatey package to the public repo
-        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: github.event_name == 'release'
         shell: bash
         run: | 
           find ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_PACKAGE_OUTPUT_DIR }}/ -name "*.nupkg" |

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Analyze/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Analyze/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Convert/Microsoft.AzureIntegrationMigration.BizTalk.Convert.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Convert/Microsoft.AzureIntegrationMigration.BizTalk.Convert.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Discover/Microsoft.AzureIntegrationMigration.BizTalk.Discover.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Discover/Microsoft.AzureIntegrationMigration.BizTalk.Discover.csproj
@@ -36,7 +36,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+		<PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Parse/Microsoft.AzureIntegrationMigration.BizTalk.Parse.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Parse/Microsoft.AzureIntegrationMigration.BizTalk.Parse.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Report/Microsoft.AzureIntegrationMigration.BizTalk.Report.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Report/Microsoft.AzureIntegrationMigration.BizTalk.Report.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners.csproj
@@ -26,8 +26,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Types/Microsoft.AzureIntegrationMigration.BizTalk.Types.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Types/Microsoft.AzureIntegrationMigration.BizTalk.Types.csproj
@@ -25,7 +25,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+	  <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
 	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-3.20181.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-3.20181.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.0" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description
- Updated the choco push step in the CI to only happen on a GitHub Release, not on a main merge, due to length of time the moderation process takes on the Chocolatey community repo, which can cause problems when pushing packages that are still in moderation.
- Updated nuget references of libraries for the AIM packages to latest version.