### PR TITLE
Fixed code analysis build issues

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -110,7 +110,7 @@ jobs:
           gpr push .\${{ env.OUTPUT_DIR }}\*.nupkg --api-key ${{ secrets.NUGET_PACKAGE_REPO_API_SECRET }}
 
       - name: Publish the plugin library and dependency files for Chocolatey
-        run: dotnet publish ${{ env.PLUGIN_PROJECT_FILE }} -r win-x64 -o ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }} --configuration ${{ env.BUILD_TYPE }} -p:Version=${{ env.VERSION_NUMBER_SEM2 }} -p:TargetFramework=netcoreapp3.1 --self-contained true
+        run: dotnet publish ${{ env.PLUGIN_PROJECT_FILE }} -r win-x64 -o ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }} --configuration ${{ env.BUILD_TYPE }} -p:Version=${{ env.VERSION_NUMBER_SEM2 }} -p:TargetFramework=net5.0 --self-contained true
 
       - name: Create the Chocolatey verification file and copy the license file
         shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   BUILD_TYPE: 'Release'
-  DOTNET_VERSION: '3.1.200'
+  DOTNET_VERSION: '5.0.x'
   CHOCO_BIZTALK_MIGRATOR_PACKAGE: '..\..\build\chocolatey\biztalkmigrator\biztalkmigrator.nuspec'
   CHOCO_CONFIG_DIR: 'build/chocolatey'
   CHOCO_PACKAGE_OUTPUT_DIR: 'choco-package'

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Analyze/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Analyze/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
     <PackageReference Include="wix-libs" Version="3.11.1" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Convert/Microsoft.AzureIntegrationMigration.BizTalk.Convert.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Convert/Microsoft.AzureIntegrationMigration.BizTalk.Convert.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Discover/Microsoft.AzureIntegrationMigration.BizTalk.Discover.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Discover/Microsoft.AzureIntegrationMigration.BizTalk.Discover.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+		<PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
 		<PackageReference Include="Mono.Cecil" Version="0.11.3" />
 	  <PackageReference Include="wix-libs" Version="3.11.1" NoWarn="NU1701" />
 	</ItemGroup>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Parse/Microsoft.AzureIntegrationMigration.BizTalk.Parse.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Parse/Microsoft.AzureIntegrationMigration.BizTalk.Parse.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Report/Microsoft.AzureIntegrationMigration.BizTalk.Report.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Report/Microsoft.AzureIntegrationMigration.BizTalk.Report.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
     <PackageReference Include="wix-libs" Version="3.11.1" NoWarn="NU1701" />
   </ItemGroup>
 

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners.csproj
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners/Microsoft.AzureIntegrationMigration.BizTalk.StageRunners.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Microsoft Corporation</Authors>
     <Product>Microsoft Azure Integration Migration Tool</Product>

--- a/src/Microsoft.AzureIntegrationMigration.BizTalk.Types/Microsoft.AzureIntegrationMigration.BizTalk.Types.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.BizTalk.Types/Microsoft.AzureIntegrationMigration.BizTalk.Types.csproj
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+	  <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
 	  <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Analyze.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Microsoft Corporation</Authors>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Cli.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Convert.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Discover.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Parse.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Microsoft Corporation</Authors>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Microsoft Corporation</Authors>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Report.Tests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.ApplicationModel" Version="0.5.2-beta.2021042628864" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests/Microsoft.AzureIntegrationMigration.BizTalk.Types.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Microsoft Corporation</Authors>


### PR DESCRIPTION
## Description
Removed the deprecated beta versions of the code analyzers and upgraded the build to .net 5 to use the ones bundled with the SDK.
Bumped the references of the migration tool nuget packages to the latest version.

## Checklist
- [ ] Only increment the version number following a GitHub Release.  Check this only if this PR is a version bump.