### PR TITLE
Choco Bug Fixes

### DIFF
--- a/config/aim-biztalk-application-templates.yaml.liquid
+++ b/config/aim-biztalk-application-templates.yaml.liquid
@@ -193,6 +193,7 @@ resourceTemplates:
       - env: ['dev', 'prod']
         paths:
           - application/standard/application.logic.workflows/.funcignore
+          - application/standard/application.logic.workflows/.gitignore.liquid
           - application/standard/application.logic.workflows/base.appsettings.local.json.liquid
           - application/standard/application.logic.workflows/base.connections.json.liquid
           - application/standard/application.logic.workflows/base.parameters.json.liquid

--- a/config/aim-biztalk-application-templates.yaml.liquid
+++ b/config/aim-biztalk-application-templates.yaml.liquid
@@ -193,7 +193,6 @@ resourceTemplates:
       - env: ['dev', 'prod']
         paths:
           - application/standard/application.logic.workflows/.funcignore
-          - application/standard/application.logic.workflows/.gitignore
           - application/standard/application.logic.workflows/base.appsettings.local.json.liquid
           - application/standard/application.logic.workflows/base.connections.json.liquid
           - application/standard/application.logic.workflows/base.parameters.json.liquid

--- a/config/aim-biztalk-messagebus-templates.yaml.liquid
+++ b/config/aim-biztalk-messagebus-templates.yaml.liquid
@@ -630,7 +630,6 @@ resourceTemplates:
       - env: ['dev', 'prod']
         paths:
           - messagebus/standard/messagebus.logic.workflows/.funcignore
-          - messagebus/standard/messagebus.logic.workflows/.gitignore
           - messagebus/standard/messagebus.logic.workflows/connections.json
           - messagebus/standard/messagebus.logic.workflows/host.json
           - messagebus/standard/messagebus.logic.workflows/local.settings.json

--- a/config/aim-biztalk-messagebus-templates.yaml.liquid
+++ b/config/aim-biztalk-messagebus-templates.yaml.liquid
@@ -630,6 +630,7 @@ resourceTemplates:
       - env: ['dev', 'prod']
         paths:
           - messagebus/standard/messagebus.logic.workflows/.funcignore
+          - messagebus/standard/messagebus.logic.workflows/.gitignore.liquid
           - messagebus/standard/messagebus.logic.workflows/connections.json
           - messagebus/standard/messagebus.logic.workflows/host.json
           - messagebus/standard/messagebus.logic.workflows/local.settings.json

--- a/config/aim-biztalk-systemapp-templates.yaml.liquid
+++ b/config/aim-biztalk-systemapp-templates.yaml.liquid
@@ -518,7 +518,6 @@ resourceTemplates:
       - env: ['dev', 'prod']
         paths:
           - intermediaries/standard/systemapplication.logic.workflows/.funcignore
-          - intermediaries/standard/systemapplication.logic.workflows/.gitignore
           - intermediaries/standard/systemapplication.logic.workflows/connections.json
           - intermediaries/standard/systemapplication.logic.workflows/host.json
           - intermediaries/standard/systemapplication.logic.workflows/local.settings.json

--- a/config/aim-biztalk-systemapp-templates.yaml.liquid
+++ b/config/aim-biztalk-systemapp-templates.yaml.liquid
@@ -518,6 +518,7 @@ resourceTemplates:
       - env: ['dev', 'prod']
         paths:
           - intermediaries/standard/systemapplication.logic.workflows/.funcignore
+          - intermediaries/standard/systemapplication.logic.workflows/.gitignore.liquid
           - intermediaries/standard/systemapplication.logic.workflows/connections.json
           - intermediaries/standard/systemapplication.logic.workflows/host.json
           - intermediaries/standard/systemapplication.logic.workflows/local.settings.json


### PR DESCRIPTION
## Description
Updated references to VSCode Template ".gitignore" files to be to ".gitignore.liquid" files
- This solves an issue with Choco not allowing ".gitignore" files in packages

## Related GitHub issue(s)
None

## Checklist
- [ ] Only increment the version number following a GitHub Release.  Check this only if this PR is a version bump.